### PR TITLE
Added cms original checker (correct order)

### DIFF
--- a/app/engine/checker.rb
+++ b/app/engine/checker.rb
@@ -21,6 +21,8 @@ class Checker
       return "#{prog} #{input_file} #{output_file} #{ans_file}"
     when 'custom_cms', 'custom_cms_raw'
       return "#{@prob_checker_file} #{input_file} #{output_file} #{ans_file}"
+    when 'custom_cms_original'
+      return "#{@prob_checker_file} #{input_file} #{ans_file} #{output_file}"
     when 'custom_cafe'
       return "#{@prob_checker_file} #{@sub.language.name} #{@testcase.num} #{input_file} #{output_file} #{ans_file} 10"
     when 'no_check'
@@ -72,9 +74,9 @@ class Checker
       end
     when 'postgres'
       return process_result_cms(out, err)
-    when 'custom_cms', 'custom_cms_raw', 'custom_cafe'
+    when 'custom_cms', 'custom_cms_raw', 'custom_cms_original', 'custom_cafe'
       if status.exitstatus == 0
-        if evaluation_type == 'custom_cms'
+        if evaluation_type == 'custom_cms' || evaluation_type == 'custom_cms_original'
           return process_result_cms(out, err)
         elsif evaluation_type == 'custom_cms_raw'
           return process_result_cms_raw(out, err)
@@ -97,7 +99,7 @@ class Checker
   def check_for_required_file
     raise "Output file [#{@output_file.cleanpath}] does not exists" unless @output_file.exist?
     raise "Answer file [#{@ans_file.cleanpath}] does not exists" unless @ans_file.exist?
-    if ['custom_cms', 'custom_cms_raw', 'custom_cafe'].include?(@ds.evaluation_type) &&
+    if ['custom_cms', 'custom_cms_raw', 'custom_cms_original', 'custom_cafe'].include?(@ds.evaluation_type) &&
         (@prob_checker_file.nil? || @prob_checker_file.exist? == false)
       raise GraderError.new("Checker file does not exists", submission_id: @sub.id)
     end

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -15,7 +15,8 @@ class Dataset < ApplicationRecord
                            custom_cafe: 3,
                            custom_cms: 4,
                            postgres: 5,
-                           custom_cms_raw: 6}
+                           custom_cms_raw: 6,
+                           custom_cms_original:7 }
 
   enum :score_type,      { sum: 0,       # summation of all testcase, default
                            group_min: 1,

--- a/app/views/datasets/_managers.html.haml
+++ b/app/views/datasets/_managers.html.haml
@@ -22,7 +22,7 @@
     = f.input :managers, label: 'Add manager', wrapper: :horizontal_file
 
   -# --- checker ---
-  - if ['custom_cafe','custom_cms','custom_cms_raw'].include? ds.evaluation_type
+  - if ['custom_cafe','custom_cms','custom_cms_raw','custom_cms_original'].include? ds.evaluation_type
     %h5.my-2.d-flex.align-items-center.gap-2
       %span.mi checkbook
       Checker

--- a/test/models/dataset_test.rb
+++ b/test/models/dataset_test.rb
@@ -9,6 +9,7 @@ class DatasetTest < ActiveSupport::TestCase
     assert ds.respond_to?(:exact?)
     assert ds.respond_to?(:custom_cafe?)
     assert ds.respond_to?(:custom_cms_raw?)
+    assert ds.respond_to?(:custom_cms_original?)
   end
 
   test "score_type enum" do


### PR DESCRIPTION
Added custom_cms_original, which has the correct ordering of checker parameters ("input, correct output, and contestant’s output"). This change doesn't break existing problems.